### PR TITLE
Update riveted.js with support for multiple simultaneous trackers

### DIFF
--- a/riveted.js
+++ b/riveted.js
@@ -38,7 +38,7 @@ var riveted = (function() {
     nonInteraction,
     universalGA,
     classicGA,
-    universalSendCommand,
+    universalSendCommands = [],
     googleTagManager,
     gaGlobal;
 
@@ -67,10 +67,20 @@ var riveted = (function() {
         googleTagManager = true;
       }
 
-      if ('gaTracker' in options && typeof options.gaTracker === 'string') {
-        universalSendCommand = options.gaTracker + '.send';
+      if ('gaTracker' in options && Array.isArray(options.gaTracker)) {
+        options.gaTracker.forEach(function(tracker) {
+          sendCommand = 'send';
+
+          if ('default' !== tracker) {
+            sendCommand = tracker + '.' + sendCommand;
+          }
+
+          universalSendCommands.push(sendCommand);
+        });
+      } else if ('gaTracker' in options && typeof options.gaTracker === 'string' && 'default' !== options.gaTracker) {
+        universalSendCommands.push(options.gaTracker + '.send');
       } else {
-        universalSendCommand = 'send';
+        universalSendCommands.push('send');
       }
 
       if (typeof options.eventHandler == 'function') {
@@ -163,7 +173,9 @@ var riveted = (function() {
       } else {
 
         if (universalGA) {
-          window[gaGlobal](universalSendCommand, 'timing', 'Riveted', 'First Interaction', timingValue);
+          universalSendCommands.forEach(function(sendCommand) {
+            window[gaGlobal](sendCommand, 'timing', 'Riveted', 'First Interaction', timingValue);
+          });
         }
 
         if (classicGA) {
@@ -187,7 +199,9 @@ var riveted = (function() {
       } else {
 
         if (universalGA) {
-          window[gaGlobal](universalSendCommand, 'event', 'Riveted', 'Time Spent', time.toString(), reportInterval, {'nonInteraction': nonInteraction});
+          universalSendCommands.forEach(function(sendCommand) {
+            window[gaGlobal](sendCommand, 'event', 'Riveted', 'Time Spent', time.toString(), reportInterval, {'nonInteraction': nonInteraction});
+          });
         }
 
         if (classicGA) {


### PR DESCRIPTION
The previous version supports multi-tracker setups with the `gaTracker` argument, which specifies a single tracker to which Riveted events will be sent. This is a bummer if you want several trackers to all receive the Riveted events so that they match (and since the data is useful everywhere). 

This patch adds support for sending events to several trackers:

- `gaTracker` now allows both the old string format for a single tracker **and** array format to pass several trackers
- `universalSendCommand` switches to array `universalSeldCommands` so it can contain commands for multiple trackers
- `init` now processes `gaTracker` based on whether it's an array, (build commands for each tracker in the array), a string (build the single command for that tracker) or empty (build a command for the default tracker). 
- `sendUserTiming` and `sendEvent` now loop through the commands in `universalSendCommands` array to send events for each registered tracker

Note that it also adds references to `default` tracker, which is a string used to indicate the main tracker that doesn't require a prefix for `ga` send commands. If you pass in multiple trackers via an array in `gaTracker` then you would use `default` to indicate that prefix-less tracker. We also made sure that if you pass in `default` as a string for a single tracker what happens is what you'd expect: The code for the prefix-less tracker is used. 

As far as we know this update is back-compatible with previous versions. If `gaTracker` is empty or a string with a single tracker, Riveted will work the same as before!

**Thanks for considering this PR!** If it can't be merged, I hope it can help someone else having the same problem as us (wanting Riveted on both of our trackers).